### PR TITLE
Run CI builds on all major OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -41,7 +45,7 @@ jobs:
         env: 
           MAVEN_OPTS: -Djansi.force=true
       - name: Publish Nightly Update Site
-        if: github.event_name != 'release' && github.ref == 'refs/heads/main' && github.repository_owner == 'vitruv-tools'
+        if: github.event_name != 'release' && github.ref == 'refs/heads/main' && github.repository_owner == 'vitruv-tools' && matrix.os == 'ubuntu-latest'
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.UPDATE_SITE_DEPLOY_KEY }}
@@ -52,7 +56,7 @@ jobs:
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
       - name: Publish Release Update Site
-        if: github.event_name == 'release' && github.repository_owner == 'vitruv-tools'
+        if: github.event_name == 'release' && github.repository_owner == 'vitruv-tools' && matrix.os == 'ubuntu-latest'
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.UPDATE_SITE_DEPLOY_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Support Longpaths [Windows]
+        if: matrix.os == 'windows-latest'
+        run: git config --system core.longpaths true
       - name: Checkout
         uses: actions/checkout@v3
       - name: Cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        exclude:
+          - os: windows-latest # TODO: Windows builds currently fail as documented in https://github.com/vitruv-tools/Vitruv-CaseStudies/issues/241
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           run: >
             ./mvnw -B clean verify 
+            -fae
             -Dstyle.color=always
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
             -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn

--- a/bundles/tools.vitruv.applications.cbs.testutils/src/tools/vitruv/applications/cbs/testutils/equivalencetest/DefaultEquivalenceTestBuilder.xtend
+++ b/bundles/tools.vitruv.applications.cbs.testutils/src/tools/vitruv/applications/cbs/testutils/equivalencetest/DefaultEquivalenceTestBuilder.xtend
@@ -150,7 +150,7 @@ package class DefaultEquivalenceTestBuilder extends DefaultBuilderCommon impleme
 				val referenceSteps = testStep.determineReferenceSteps(steps)
 				var testName = '''FROM «testMetamodel.name» TO {«FOR rd : referenceSteps.keySet SEPARATOR ', '»«rd.name»«ENDFOR»}'''
 				if (testStep.name !== null) {
-					testName += ''' — «testStep.name»'''
+					testName += ''' - «testStep.name»'''
 				}
 				val testContext = new EquivalenceTestExtensionContext(testName, testIndex, parentContext,
 					testStep.targetMetamodel)

--- a/bundles/tools.vitruv.applications.cbs.testutils/src/tools/vitruv/applications/cbs/testutils/equivalencetest/DefaultEquivalenceTestBuilder.xtend
+++ b/bundles/tools.vitruv.applications.cbs.testutils/src/tools/vitruv/applications/cbs/testutils/equivalencetest/DefaultEquivalenceTestBuilder.xtend
@@ -148,7 +148,7 @@ package class DefaultEquivalenceTestBuilder extends DefaultBuilderCommon impleme
 				val testStep = modifyIfNecessary(args.value)
 					
 				val referenceSteps = testStep.determineReferenceSteps(steps)
-				var testName = '''«testMetamodel.name» «'\u2192' /* right arrow */ » {«FOR rd : referenceSteps.keySet SEPARATOR ', '»«rd.name»«ENDFOR»}'''
+				var testName = '''FROM «testMetamodel.name» TO {«FOR rd : referenceSteps.keySet SEPARATOR ', '»«rd.name»«ENDFOR»}'''
 				if (testStep.name !== null) {
 					testName += ''' — «testStep.name»'''
 				}


### PR DESCRIPTION
This PR adds support to run the validation GitHub Actions on all major OS (Linux, Windows, macOS).
Releases are still built and released on Ubuntu only.

For now, Windows builds are disabled as they fail. This behavior is documented #241.

⚠️ Before merging this, the branch protection rules need to be adjusted to the modified jobs ⚠️

Follows [Vitruv-Change#24](https://github.com/vitruv-tools/Vitruv-Change/pull/24)