### PR TITLE
Update RepositoryCopmonentConceptTest in PCM-UML-tests to viewbased

### DIFF
--- a/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/InterfaceConceptTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/InterfaceConceptTest.xtend
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals
 import static tools.vitruv.applications.pcmumlclass.tests.PcmUmlElementEqualityValidation.*
 import static extension tools.vitruv.applications.pcmumlclass.tests.PcmQueryUtil.*
 import static extension tools.vitruv.applications.testutility.uml.UmlQueryUtil.*
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimOne
 
 /**
  *  This test class tests the reactions and routines are supposed to synchronize a pcm::OperationInterface
@@ -70,10 +71,8 @@ class InterfaceConceptTest extends PcmUmlClassApplicationTest {
 		// Ensure preconditions for rename are fulfilled:
 		validateUmlAndPcmPackagesView[
 			assertNotNull(umlContractsPackage.claimInterface(TEST_INTERFACE_NAME))
-			assertEquals(1, defaultPcmRepository.interfaces__Repository.size,
-				"There should be exactly one element in list.")
 			assertEquals(TEST_INTERFACE_NAME,
-				(defaultPcmRepository.interfaces__Repository.get(0) as OperationInterface).entityName)
+				(defaultPcmRepository.interfaces__Repository.claimOne as OperationInterface).entityName)
 		]
 
 		changeUmlView[
@@ -105,16 +104,13 @@ class InterfaceConceptTest extends PcmUmlClassApplicationTest {
 
 		// Ensure preconditions for rename are fulfilled:
 		validateUmlAndPcmPackagesView[
-			assertEquals(1, defaultPcmRepository.interfaces__Repository.size,
-				"There should be exactly one element in list.")
-			assertEquals(TEST_INTERFACE_NAME,
-				(defaultPcmRepository.interfaces__Repository.get(0) as OperationInterface).entityName)
 			assertNotNull(umlContractsPackage.claimInterface(TEST_INTERFACE_NAME))
+			assertEquals(TEST_INTERFACE_NAME,
+				(defaultPcmRepository.interfaces__Repository.claimOne as OperationInterface).entityName)
 		]
 
 		changePcmView [
-			(defaultPcmRepository.interfaces__Repository.
-				get(0) as OperationInterface).entityName = NEW_TEST_INTERFACE_NAME
+			(defaultPcmRepository.interfaces__Repository.claimOne as OperationInterface).entityName = NEW_TEST_INTERFACE_NAME
 		]
 
 		// Check consistency is restored
@@ -140,10 +136,8 @@ class InterfaceConceptTest extends PcmUmlClassApplicationTest {
 		// Ensure preconditions for deletion are fulfilled:
 		validateUmlAndPcmPackagesView[
 			assertNotNull(umlContractsPackage.claimInterface(TEST_INTERFACE_NAME))
-			assertEquals(1, defaultPcmRepository.interfaces__Repository.size,
-				"There should be exactly one element in list.")
 			assertEquals(TEST_INTERFACE_NAME,
-				(defaultPcmRepository.interfaces__Repository.get(0) as OperationInterface).entityName)
+				(defaultPcmRepository.interfaces__Repository.claimOne as OperationInterface).entityName)
 		]
 
 		changeUmlView[
@@ -174,11 +168,9 @@ class InterfaceConceptTest extends PcmUmlClassApplicationTest {
 
 		// Ensure preconditions for deletion are fulfilled:
 		validateUmlAndPcmPackagesView[
-			assertEquals(1, defaultPcmRepository.interfaces__Repository.size,
-				"There should be exactly one element in list.")
-			assertEquals(TEST_INTERFACE_NAME,
-				(defaultPcmRepository.interfaces__Repository.get(0) as OperationInterface).entityName)
 			assertNotNull(umlContractsPackage.claimInterface(TEST_INTERFACE_NAME))
+			assertEquals(TEST_INTERFACE_NAME,
+				(defaultPcmRepository.interfaces__Repository.claimOne as OperationInterface).entityName)
 		]
 
 		changePcmView [

--- a/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/PcmUmlElementEqualityValidation.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/PcmUmlElementEqualityValidation.xtend
@@ -41,6 +41,8 @@ class PcmUmlElementEqualityValidation {
 				uPackage.packagedElements.findFirst[it.name == DefaultLiterals.CONTRACTS_PACKAGE_NAME].eContents,
 				repoPackage.interfaces__Repository)
 		}
+		
+		//if (!repoPackage.components__Repository.isEmpty || uPackage.packagedElements.exists[it.])
 	}
 
 	def static dispatch void assertElementsEqual(List<org.eclipse.uml2.uml.Interface> umlContracts,

--- a/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/PcmUmlElementEqualityValidation.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/PcmUmlElementEqualityValidation.xtend
@@ -42,11 +42,13 @@ class PcmUmlElementEqualityValidation {
 				uPackage.packagedElements.findFirst[it.name == DefaultLiterals.CONTRACTS_PACKAGE_NAME].eContents,
 				repoPackage.interfaces__Repository)
 		}
-		
-		if (!repoPackage.components__Repository.isEmpty 
-			|| !uPackage.nestedPackages.filter[it.ownedMembers.exists[it.name.contains(DefaultLiterals.IMPLEMENTATION_SUFFIX)]].isEmpty) {
-			assertComponentsEqual(uPackage.nestedPackages.filter[it.allOwnedElements.exists[it.toString.contains(DefaultLiterals.IMPLEMENTATION_SUFFIX)]].toList, 
-				repoPackage.components__Repository)
+
+		if (!repoPackage.components__Repository.isEmpty || !uPackage.nestedPackages.filter [
+			it.ownedMembers.exists[it.name.contains(DefaultLiterals.IMPLEMENTATION_SUFFIX)]
+		].isEmpty) {
+			assertComponentsEqual(uPackage.nestedPackages.filter [
+				it.allOwnedElements.exists[it.toString.contains(DefaultLiterals.IMPLEMENTATION_SUFFIX)]
+			].toList, repoPackage.components__Repository)
 		}
 	}
 
@@ -61,21 +63,22 @@ class PcmUmlElementEqualityValidation {
 			assertTrue(umlContracts.exists[it.name.equals(pcmInterface.entityName)], "PCM interfaces incomplete")
 		}
 	}
-	
-	def static void assertComponentsEqual(List<org.eclipse.uml2.uml.Package> umlComponents, 
+
+	def static void assertComponentsEqual(List<org.eclipse.uml2.uml.Package> umlComponents,
 		List<org.palladiosimulator.pcm.repository.RepositoryComponent> pcmComponents) {
 		assertEquals(umlComponents.size, pcmComponents.size)
-		println("EQUALITY")
+
 		for (org.palladiosimulator.pcm.repository.RepositoryComponent pcmComponent : pcmComponents) {
-			umlComponents.forEach[println(it.allOwnedElements)]
 			assertTrue(umlComponents.exists[it.name.equals(pcmComponent.entityName.toFirstLower)])
-			
-			//contains a class with implementation
-			assertTrue(umlComponents.filter[it.name.equals(pcmComponent.entityName.toFirstLower)].claimOne.members
-				.exists[it.name.startsWith(pcmComponent.entityName)]
+
+			// contains a class with implementation
+			assertTrue(
+				umlComponents.filter[it.name.equals(pcmComponent.entityName.toFirstLower)].claimOne.members.exists [
+					it.name.startsWith(pcmComponent.entityName)
+				]
 			)
 		}
-		
+
 		for (org.eclipse.uml2.uml.Package umlComponent : umlComponents) {
 			assertTrue(pcmComponents.exists[it.entityName.equals(umlComponent.name.toFirstUpper)])
 		}

--- a/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/PcmUmlElementEqualityValidation.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/PcmUmlElementEqualityValidation.xtend
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.junit.jupiter.api.Assertions.assertFalse
 import static org.junit.jupiter.api.Assertions.assertNull
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimOne
 
 class PcmUmlElementEqualityValidation {
 
@@ -42,7 +43,11 @@ class PcmUmlElementEqualityValidation {
 				repoPackage.interfaces__Repository)
 		}
 		
-		//if (!repoPackage.components__Repository.isEmpty || uPackage.packagedElements.exists[it.])
+		if (!repoPackage.components__Repository.isEmpty 
+			|| !uPackage.nestedPackages.filter[it.ownedMembers.exists[it.name.contains(DefaultLiterals.IMPLEMENTATION_SUFFIX)]].isEmpty) {
+			assertComponentsEqual(uPackage.nestedPackages.filter[it.allOwnedElements.exists[it.toString.contains(DefaultLiterals.IMPLEMENTATION_SUFFIX)]].toList, 
+				repoPackage.components__Repository)
+		}
 	}
 
 	def static dispatch void assertElementsEqual(List<org.eclipse.uml2.uml.Interface> umlContracts,
@@ -54,6 +59,25 @@ class PcmUmlElementEqualityValidation {
 		}
 		for (org.palladiosimulator.pcm.repository.Interface pcmInterface : pcmInterfaces) {
 			assertTrue(umlContracts.exists[it.name.equals(pcmInterface.entityName)], "PCM interfaces incomplete")
+		}
+	}
+	
+	def static void assertComponentsEqual(List<org.eclipse.uml2.uml.Package> umlComponents, 
+		List<org.palladiosimulator.pcm.repository.RepositoryComponent> pcmComponents) {
+		assertEquals(umlComponents.size, pcmComponents.size)
+		println("EQUALITY")
+		for (org.palladiosimulator.pcm.repository.RepositoryComponent pcmComponent : pcmComponents) {
+			umlComponents.forEach[println(it.allOwnedElements)]
+			assertTrue(umlComponents.exists[it.name.equals(pcmComponent.entityName.toFirstLower)])
+			
+			//contains a class with implementation
+			assertTrue(umlComponents.filter[it.name.equals(pcmComponent.entityName.toFirstLower)].claimOne.members
+				.exists[it.name.startsWith(pcmComponent.entityName)]
+			)
+		}
+		
+		for (org.eclipse.uml2.uml.Package umlComponent : umlComponents) {
+			assertTrue(pcmComponents.exists[it.entityName.equals(umlComponent.name.toFirstUpper)])
 		}
 	}
 

--- a/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/RepositoryComponentConceptTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/RepositoryComponentConceptTest.xtend
@@ -1,24 +1,16 @@
 package tools.vitruv.applications.pcmumlclass.tests
 
-import org.eclipse.uml2.uml.Class
-import org.eclipse.uml2.uml.Operation
-import org.eclipse.uml2.uml.Package
-import org.eclipse.uml2.uml.VisibilityKind
 import org.palladiosimulator.pcm.repository.CompositeComponent
-import org.palladiosimulator.pcm.repository.Repository
-import org.palladiosimulator.pcm.repository.RepositoryComponent
 import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.DefaultLiterals
-import tools.vitruv.applications.pcmumlclass.TagLiterals
 import org.junit.jupiter.api.Test
-
 import static org.junit.jupiter.api.Assertions.assertNotNull
-import static org.junit.jupiter.api.Assertions.assertTrue
-import java.nio.file.Path
-import static extension tools.vitruv.applications.pcmumlclass.PcmUmlClassHelper.isPackageFor
+import static org.junit.jupiter.api.Assertions.assertEquals
 import static tools.vitruv.applications.pcmumlclass.tests.PcmUmlElementEqualityValidation.*
 import static extension tools.vitruv.applications.pcmumlclass.tests.PcmQueryUtil.*
 import static extension tools.vitruv.applications.testutility.uml.UmlQueryUtil.*
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimOne
+
 /**
  * This test class tests the reactions and routines that are supposed to synchronize synchronize a pcm::RepositoryComponent with 
  * its corresponding uml::Package, uml::Class (implementation), and uml::Operation (constructor).
@@ -32,24 +24,23 @@ import static extension tools.vitruv.applications.testutility.uml.UmlQueryUtil.*
 class RepositoryComponentConceptTest extends PcmUmlClassApplicationTest {
 
 	val COMPONENT_NAME = "testComponent"
+	val NEW_COMPONENT_NAME = "newTestComponent"
 
 	@Test
-	def void testRepositoryComponentConcept_PCM() {
+	def void testCreateRepositoryComponentConcept_PCM() {
 		initPCMRepository
-		
+
 		changePcmView[
 			var pcmComponent = RepositoryFactory.eINSTANCE.createCompositeComponent
 			pcmComponent.entityName = COMPONENT_NAME
 			defaultPcmRepository.components__Repository += pcmComponent
 		]
-		
+
 		validateUmlAndPcmPackagesView [
 			val umlPackage = defaultUmlModel.claimPackage(PACKAGE_NAME)
 			val pcmPackage = claimPcmRepository(PACKAGE_NAME_FIRST_UPPER)
 
-			println("uml " + umlPackage.allOwnedElements)
-			println("uml " + umlPackage.eContents)
-			//assertNotNull(umlContractsPackage.ownedElements)
+			assertNotNull(umlPackage.claimPackage(COMPONENT_NAME))
 			assertNotNull(pcmPackage.eContents)
 
 			assertElementsEqual(umlPackage, pcmPackage)
@@ -57,7 +48,88 @@ class RepositoryComponentConceptTest extends PcmUmlClassApplicationTest {
 	}
 
 	@Test
-	def void testRepositoryComponentConcept_UML() {
-		
+	def void testCreateRepositoryComponentConcept_UML() {
+		initUMLModel
+
+		changeUmlView[
+			userInteraction.addNextSingleSelection(
+				DefaultLiterals.USER_DISAMBIGUATE_REPOSITORYCOMPONENT_TYPE__COMPOSITE_COMPONENT)
+			umlRootPackage.createNestedPackage(COMPONENT_NAME)
+		]
+
+		validateUmlAndPcmPackagesView [
+			val umlPackage = defaultUmlModel.claimPackage(PACKAGE_NAME)
+			val pcmPackage = claimPcmRepository(PACKAGE_NAME_FIRST_UPPER)
+
+			assertNotNull(umlPackage.claimPackage(COMPONENT_NAME))
+			assertNotNull(pcmPackage.eContents)
+
+			assertElementsEqual(umlPackage, pcmPackage)
+		]
+	}
+
+	@Test
+	def void testRenameRepositoryComponentConcept_PCM() {
+		initPCMRepository
+
+		changePcmView[
+			var pcmComponent = RepositoryFactory.eINSTANCE.createCompositeComponent
+			pcmComponent.entityName = COMPONENT_NAME
+			defaultPcmRepository.components__Repository += pcmComponent
+		]
+
+		// Ensure preconditions for rename are fulfilled:
+		validateUmlAndPcmPackagesView[
+			assertNotNull(umlRootPackage.claimPackage(COMPONENT_NAME))
+			assertEquals(COMPONENT_NAME.toFirstUpper,
+				(defaultPcmRepository.components__Repository.claimOne as CompositeComponent).entityName)
+		]
+
+		changePcmView[
+			(defaultPcmRepository.components__Repository.
+				claimOne as CompositeComponent).entityName = NEW_COMPONENT_NAME.toFirstUpper
+		]
+
+		validateUmlAndPcmPackagesView [
+			val umlPackage = defaultUmlModel.claimPackage(PACKAGE_NAME)
+			val pcmPackage = claimPcmRepository(PACKAGE_NAME_FIRST_UPPER)
+
+			assertNotNull(umlPackage.claimPackage(NEW_COMPONENT_NAME))
+			assertNotNull(pcmPackage.eContents)
+
+			assertElementsEqual(umlPackage, pcmPackage)
+		]
+	}
+
+	@Test
+	def void testRenameRepositoryComponentConcept_UML() {
+		initUMLModel
+
+		changeUmlView[
+			userInteraction.addNextSingleSelection(
+				DefaultLiterals.USER_DISAMBIGUATE_REPOSITORYCOMPONENT_TYPE__COMPOSITE_COMPONENT)
+			umlRootPackage.createNestedPackage(COMPONENT_NAME)
+		]
+
+		// Ensure preconditions for rename are fulfilled:
+		validateUmlAndPcmPackagesView[
+			assertNotNull(umlRootPackage.claimPackage(COMPONENT_NAME))
+			assertEquals(COMPONENT_NAME.toFirstUpper,
+				(defaultPcmRepository.components__Repository.claimOne as CompositeComponent).entityName)
+		]
+
+		changeUmlView[
+			umlRootPackage.claimPackage(COMPONENT_NAME).name = NEW_COMPONENT_NAME
+		]
+
+		validateUmlAndPcmPackagesView [
+			val umlPackage = defaultUmlModel.claimPackage(PACKAGE_NAME)
+			val pcmPackage = claimPcmRepository(PACKAGE_NAME_FIRST_UPPER)
+
+			assertNotNull(umlPackage.claimPackage(NEW_COMPONENT_NAME))
+			assertNotNull(pcmPackage.eContents)
+
+			assertElementsEqual(umlPackage, pcmPackage)
+		]
 	}
 }

--- a/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/RepositoryComponentConceptTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/RepositoryComponentConceptTest.xtend
@@ -6,6 +6,7 @@ import tools.vitruv.applications.pcmumlclass.DefaultLiterals
 import org.junit.jupiter.api.Test
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertTrue
 import static tools.vitruv.applications.pcmumlclass.tests.PcmUmlElementEqualityValidation.*
 import static extension tools.vitruv.applications.pcmumlclass.tests.PcmQueryUtil.*
 import static extension tools.vitruv.applications.testutility.uml.UmlQueryUtil.*
@@ -128,6 +129,70 @@ class RepositoryComponentConceptTest extends PcmUmlClassApplicationTest {
 
 			assertNotNull(umlPackage.claimPackage(NEW_COMPONENT_NAME))
 			assertNotNull(pcmPackage.eContents)
+
+			assertElementsEqual(umlPackage, pcmPackage)
+		]
+	}
+
+	@Test
+	def void testDeleteRepositoryComponentConcept_PCM() {
+		initPCMRepository
+
+		changePcmView[
+			var pcmComponent = RepositoryFactory.eINSTANCE.createCompositeComponent
+			pcmComponent.entityName = COMPONENT_NAME
+			defaultPcmRepository.components__Repository += pcmComponent
+		]
+
+		// Ensure preconditions for delete are fulfilled:
+		validateUmlAndPcmPackagesView[
+			assertNotNull(umlRootPackage.claimPackage(COMPONENT_NAME))
+			assertEquals(COMPONENT_NAME.toFirstUpper,
+				(defaultPcmRepository.components__Repository.claimOne as CompositeComponent).entityName)
+		]
+
+		changePcmView[
+			defaultPcmRepository.components__Repository.remove(0)
+		]
+
+		validateUmlAndPcmPackagesView [
+			val umlPackage = defaultUmlModel.claimPackage(PACKAGE_NAME)
+			val pcmPackage = claimPcmRepository(PACKAGE_NAME_FIRST_UPPER)
+
+			assertTrue(umlPackage.nestedPackages.filter[it.name.equals(COMPONENT_NAME)].empty)
+			assertTrue(pcmPackage.eContents.empty)
+
+			assertElementsEqual(umlPackage, pcmPackage)
+		]
+	}
+
+	@Test
+	def void testDeleteRepositoryComponentConcept_UML() {
+		initUMLModel
+
+		changeUmlView[
+			userInteraction.addNextSingleSelection(
+				DefaultLiterals.USER_DISAMBIGUATE_REPOSITORYCOMPONENT_TYPE__COMPOSITE_COMPONENT)
+			umlRootPackage.createNestedPackage(COMPONENT_NAME)
+		]
+
+		// Ensure preconditions for delete are fulfilled:
+		validateUmlAndPcmPackagesView[
+			assertNotNull(umlRootPackage.claimPackage(COMPONENT_NAME))
+			assertEquals(COMPONENT_NAME.toFirstUpper,
+				(defaultPcmRepository.components__Repository.claimOne as CompositeComponent).entityName)
+		]
+
+		changeUmlView[
+			umlRootPackage.claimPackage(COMPONENT_NAME).destroy
+		]
+
+		validateUmlAndPcmPackagesView [
+			val umlPackage = defaultUmlModel.claimPackage(PACKAGE_NAME)
+			val pcmPackage = claimPcmRepository(PACKAGE_NAME_FIRST_UPPER)
+
+			assertTrue(umlPackage.nestedPackages.filter[it.name.equals(COMPONENT_NAME)].empty)
+			assertTrue(pcmPackage.eContents.empty)
 
 			assertElementsEqual(umlPackage, pcmPackage)
 		]


### PR DESCRIPTION
This pull request follows issue https://github.com/vitruv-tools/Vitruv-CaseStudies/issues/242 , which mentions only part of the PCM-UML-tests are updated to the ViewBasedVitruvApplicationTest. This pull request is to update another class, RepositoryComponenConceptTest, to Viewbased.