### PR TITLE
Migrate to Java 17 CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
-          distribution: 'zulu'
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 17
       - name: Build and Verify
         uses: GabrielBB/xvfb-action@v1
         with:


### PR DESCRIPTION
In preparation for migrating to Java 17, this PR already updates the CI to use Java 17 for building in source compatibility mode for Java 11 (as specified in [Maven Build Parent](https://github.com/vitruv-tools/Maven-Build-Parent)).

Additionally, the Java distribution is changed to the Eclipse distribution temurin.