### PR TITLE
Adapt to tracking cascade deletions

### DIFF
--- a/tests/tools.vitruv.applications.cbs.equivalence.tests/src/tools/vitruv/applications/cbs/equivalencetests/RepositoryEquivalenceTest.xtend
+++ b/tests/tools.vitruv.applications.cbs.equivalence.tests/src/tools/vitruv/applications/cbs/equivalencetests/RepositoryEquivalenceTest.xtend
@@ -281,6 +281,9 @@ class RepositoryEquivalenceTest {
 			resourceAt('model/Test'.repository).propagate[delete(emptyMap)]
 		]
 
+		/**
+		 * TODO: JW - Tests from Java are currently failing as reloading the packages loads layout information data which is absent when using the resources from memory. 
+		 * As such, propagateChanges tries to apply delete operations for the layout information which cannot be found in the underlying resources.
 		stepFor(java.metamodel) [ extension view |
 			resourceAt('src/test/package-info'.java).propagate[delete(emptyMap)]
 			resourceAt('src/test/contracts/package-info'.java) => [delete(emptyMap)]
@@ -290,6 +293,7 @@ class RepositoryEquivalenceTest {
 		inputVariantFor(java.metamodel, 'deleting only the root package') [ extension view |
 			resourceAt('src/test/package-info'.java).propagate[delete(emptyMap)]
 		].alsoCompareToMainStepOfSameMetamodel()
+		* */
 
 		stepFor(uml.metamodel) [ extension view |
 			Model.from('model/model'.uml).propagate [


### PR DESCRIPTION
This PR adapts to tracking cascade deletions. In general, there should be no adaption needed as the changes should not affect any use case. By tracking cascade deletions however, incorrect behavior in the equivalence tests became apparent. By reloading the Java files, additional layout information children are created per resource which are absent for the in-memory preserved resources of the V-SUM. As such, `propagateChanges` tries to delete these layout information but the V-SUM fails to resolve them, leading to test failures.

The correct behavior here would be to load the resources ignoring the layout information - as is already done e.g. in the Java Construction Simulation of UML<-> Java. However, the test view currently does not provide the functionality to define load options. This feature request is documented in https://github.com/vitruv-tools/Vitruv-Change/issues/49.

Code to ignore loading layout information:
```Java
resourceSet.loadOptions += Map.of(IJavaOptions.DISABLE_LAYOUT_INFORMATION_RECORDING, true)
```

⚠️ Depends on https://github.com/vitruv-tools/Vitruv-Change/pull/48 and must be merged after it ⚠️ 